### PR TITLE
Modify user.rbのアソシエーション

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,23 +28,17 @@ class UsersController < ApplicationController
   end
 
   def followings
-    user = User.find(params[:id])
-    @users = user.followings.page(params[:page]).per(16)
+    @user = User.find(params[:id])
+    @users = @user.followings.page(params[:page]).per(16)
   end
 
   def followers
-    user = User.find(params[:id])
-    @users = user.followers.page(params[:page]).per(16)
+    @user = User.find(params[:id])
+    @users = @user.followers.page(params[:page]).per(16)
   end
 
   def favorites
-    user = User.find(params[:id])
-    favorites = Favorite.where(user_id: user.id).pluck(:post_id)
-    # pluck:指定したモデルのカラムのレコードをすべて取得(そのユーザーがいいねしたpost_idをfavoritesテーブルから検索)
-    @favorite_posts = Post.find(favorites)
-    # 見つけたpost_idの情報をPostsテーブルから探し代入
-    @favorite_posts = Kaminari.paginate_array(@favorite_posts).page(params[:page]).per(12)
-    # findやwhereメソッドはArrayオブジェクト(配列)、pageの使用方法が変わる(通常はActiveRecordオブジェクトに対して)
+    @favorite_posts = User.find(params[:id]).favorite_posts.page(params[:page]).per(12)
   end
 
   def destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy
   has_many :favorites, dependent: :destroy
+  has_many :favorite_posts, through: :favorites, source: :post # ユーザーがいいねした投稿をuser.favorite_postsで呼び出し可能
   has_many :post_comments, dependent: :destroy
   attachment :profile_image
   # refileがカラム名にアクセスするためのもの、imageはカラム名だがidはつけない

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <h2 class="head-title my-5"><%= @user.nickname %>さんのフォロワー一覧</h2>
   <div class="row mt-5">
     <%= render 'users/index', users: @users %>
   </div>

--- a/app/views/users/followings.html.erb
+++ b/app/views/users/followings.html.erb
@@ -1,4 +1,5 @@
 <div class="container">
+  <h2 class="head-title my-5"><%= @user.nickname %>さんのフォロー一覧</h2>
   <div class="row mt-5">
     <%= render 'users/index', users: @users %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
               <% end %></th>
         </tr>
         <tr>
-          <td>フォロー中</td>
+          <td>フォロー</td>
           <td><%= link_to followings_user_path(@user.id) do %>
                 <%= @user.followings.count %>
               <% end %></td>


### PR DESCRIPTION
変更点
・user.rbにfavorite_postsのアソシエーションを定義
Kaminari.paginate_array(@favorite_posts).page(params[:page]).per(12)で取得済みの@favorite_postsに対してページネーションを適用していたが、@favorite_postsが大量にある場合は、パフォーマンスに影響が出ると指摘を受け、データーベースから取得するためuser.rbに記述追加

・フォロー/フォロワー一覧の見出しに「誰のフォロワー一覧」かを分かるようにviewsに記述追加